### PR TITLE
Tweak the readme for hbs tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ via ES6 tagged template strings:
 
 ``` js
 // ember-cli-project/test/unit/components/my-component-test.js
-import precompile from 'htmlbars-inline-precompile';
+import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 
 moduleForComponent('my-component');
@@ -15,10 +15,12 @@ moduleForComponent('my-component');
 test('it renders', function(assert) {
   var component = this.subject({
     greeting: "hello ember testing",
-    layout: precompile`greeting: {{greeting}}`
+    layout: hbs`
+      greeting: <span>{{greeting}}</span>
+    `
   });
 
-  assert.equal(this.$().text().trim(), "greeting: hello ember testing");
+  assert.equal(this.$().html().trim(), "greeting: <span>hello ember testing</span>");
 });
 ```
 


### PR DESCRIPTION
Suggest that users consume the export as `hbs`. Makes for some nice looking templates and is shorter ;-)