### PR TITLE
Bump babel-plugin-htmlbars-inline-precompile to v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## master
+
+- Bump `belbabel-plugin-htmlbars-inline-precompile` to `0.0.3`
+
 ## 0.1.1 (2015-06-13)
 
 - Bump `belbabel-plugin-htmlbars-inline-precompile` to `0.0.2`

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-cli"
   ],
   "dependencies": {
-    "babel-plugin-htmlbars-inline-precompile": "0.0.2",
+    "babel-plugin-htmlbars-inline-precompile": "0.0.3",
     "ember-cli-babel": "^5.0.0",
     "ember-cli-htmlbars": "^0.7.6"
   },


### PR DESCRIPTION
This version of `babel-plugin-htmlbars-inline-precompile` fixes a deprecation warning.