### PR TITLE
Fix usage within multi-EmberApp builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,10 @@ module.exports = {
 
     // add the HTMLBarsInlinePrecompilePlugin to the list of plugins used by
     // the `ember-cli-babel` addon
-    app.options.babel.plugins.push(PrecompileInlineHTMLBarsPlugin);
+    if (!this._registeredWithBabel) {
+      app.options.babel.plugins.push(PrecompileInlineHTMLBarsPlugin);
+      this._registeredWithBabel = true;
+    }
   },
 
   // borrowed from ember-cli-htmlbars http://git.io/vJDrW


### PR DESCRIPTION
It is possible to have more than one instanceof EmberApp in an ember-cli-build.js. In this case, an addon's `included` hook will run multiple times.

This is causing ember-cli-htmlbars-inline-precompile to register multiple times with babel, resulting in a build failure.